### PR TITLE
WaitAndClose Failsafe Conditions

### DIFF
--- a/SysBot.Pokemon/SV/BotSV/EggBot.cs
+++ b/SysBot.Pokemon/SV/BotSV/EggBot.cs
@@ -146,13 +146,16 @@ namespace SysBot.Pokemon
                         waiting++;
                         await Task.Delay(1_500, token).ConfigureAwait(false);
                         pk = await ReadPokemonSV(EggData, 344, token).ConfigureAwait(false);
-                        if (waiting == 50)
+                        if (waiting == 80)
                         {
-                            waiting = 0;
-                            ctr = 0;
+                            Log("2 minutes have passed without an egg.  Attempting full recovery.");
                             await ReopenPicnic(token).ConfigureAwait(false);
                             await MakeSandwich(token).ConfigureAwait(false);
-                            continue;
+                            await ReopenPicnic(token).ConfigureAwait(false);
+                            wait = TimeSpan.FromMinutes(30);
+                            endTime = DateTime.Now + wait;
+                            waiting = 0;
+                            ctr = 0;
                         }
                     }
 

--- a/SysBot.Pokemon/SV/BotSV/EggBot.cs
+++ b/SysBot.Pokemon/SV/BotSV/EggBot.cs
@@ -157,10 +157,8 @@ namespace SysBot.Pokemon
                 await Click(DRIGHT, 0_250, token).ConfigureAwait(false);
                 await Click(DDOWN, 0_250, token).ConfigureAwait(false);
                 await Click(DDOWN, 0_250, token).ConfigureAwait(false);
-                await Click(A, 7_000, token).ConfigureAwait(false); //first picnic opening takes longer, so lets give it a little more time
             }
-            else
-                await Click(A, 4_500, token).ConfigureAwait(false);
+            await Click(A, 7_000, token).ConfigureAwait(false); //first picnic *might* take longer.  value originally was 4_500
         }
 
         private async Task WaitForEggs(CancellationToken token)

--- a/SysBot.Pokemon/SV/BotSV/EggBot.cs
+++ b/SysBot.Pokemon/SV/BotSV/EggBot.cs
@@ -130,15 +130,12 @@ namespace SysBot.Pokemon
 
                 if (overworldWaitCycles == 10)
                 {
-                    Log("Attempting to leave menus.");
                     for (int i = 0; i < 5; i++)
                         await Click(B, 0_500, token).ConfigureAwait(false); // Click a few times to attempt to escape any menu
 
-                    Log("Attempting to leave picnic again.");
                     await Click(Y, 1_500, token).ConfigureAwait(false); // Attempt to leave the picnic again, in case you were stuck interacting with a pokemon
                     await Click(A, 1_000, token).ConfigureAwait(false); // Overworld seems to trigger true when you leave the Pokemon washing mode, so we have to try to exit picnic immediately
                     
-                    Log("Attempting to leave menus again.");
                     for (int i = 0; i < 4; i++)
                         await Click(B, 0_500, token).ConfigureAwait(false); // Click a few times to attempt to escape any menu
                 }
@@ -183,7 +180,7 @@ namespace SysBot.Pokemon
                         waiting++;
                         await Task.Delay(1_500, token).ConfigureAwait(false);
                         pk = await ReadPokemonSV(EggData, 344, token).ConfigureAwait(false);
-                        if (waiting == 5)
+                        if (waiting == 80)
                         {
                             Log("2 minutes have passed without an egg.  Attempting full recovery.");
                             await ReopenPicnic(token).ConfigureAwait(false);


### PR DESCRIPTION
Added failsafes to the WaitandClose mode to block several stuck states
 - Should escape wash mode
 - Should escape snapshot mode
 - Forces a reset after a minute if nothing else works, and returns to the loop