### PR TITLE
Reorder IVs to speed be the last for Genie searching

### DIFF
--- a/SysBot.Pokemon/LA/BotArceus/ArceusBot.cs
+++ b/SysBot.Pokemon/LA/BotArceus/ArceusBot.cs
@@ -1716,7 +1716,11 @@ namespace SysBot.Pokemon
                     pk.Species = (ushort)geniename;
                     pk.EncryptionConstant = gen.EC;
                     pk.PID = gen.PID;
+
                     int[] pkIVList = gen.IVs;
+                    // Reorder the speed to be last.
+                    (pkIVList[5], pkIVList[3], pkIVList[4]) = (pkIVList[3], pkIVList[4], pkIVList[5]);
+
                     pk.IVs = pkIVList;
                     pk.Nature = (int)gen.nature;
                     Log($"\nAdvance: {i} - {geniename}\nEC: {pk.EncryptionConstant:X8}\nPID: {pk.PID:X8}\nIVs: {string.Join("/", pk.IVs)}\nNature: {(Nature)pk.Nature}\nGenerator Seed: {generator_seed:X16}");


### PR DESCRIPTION
Hi! While searching for a target I figured that the SpA en Spe IVs were wrong.
- The `GenerateFromSeed` method returns IVs like HP/Atk/Def/SpA/SpD/Spe
- But `pk.IVs = pkIVList` inserts IVs like HP/Atk/Def/Spe/SpA/SpD (see PkHeX source: https://github.com/kwsch/PKHeX/blob/master/PKHeX.Core/PKM/PKM.cs#L376)
- In the `EncounterFound` method is another `// Reorder the speed to be last.`, therefore I think it necessary to reorder IVs before inserting into the `Pk` object.