### PR TITLE
Add back functionality to set index on defeating raid

### DIFF
--- a/SysBot.Pokemon/SV/BotRaid/RaidEnum.cs
+++ b/SysBot.Pokemon/SV/BotRaid/RaidEnum.cs
@@ -29,6 +29,12 @@ namespace SysBot.Pokemon
         TurboA,
     }
 
+    public enum IndexSetting
+    {
+        DefeatedDen,
+        PreInjected,
+    }
+
     public class BanList
     {
         public bool enabled { get; set; }

--- a/SysBot.Pokemon/SV/BotRotatingRaid/RotatingRaidSettingsSV.cs
+++ b/SysBot.Pokemon/SV/BotRotatingRaid/RotatingRaidSettingsSV.cs
@@ -32,6 +32,9 @@ namespace SysBot.Pokemon
         [Category(Hosting), Description("Raid embed parameters.")]
         public List<RotatingRaidParameters> RaidEmbedParameters { get; set; } = new();
 
+        [Category(Hosting), Description("Choose how you want to set your index.")]
+        public IndexSetting SetDenIndexMethod { get; set; } = IndexSetting.DefeatedDen;
+
         [Category(Hosting), Description("Enter the total number of raids to host before the bot automatically stops. Default is 0 to ignore this setting.")]
         public int TotalRaidsToHost { get; set; } = 0;
 
@@ -166,5 +169,5 @@ namespace SysBot.Pokemon
 
             public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType) => destinationType != typeof(string) && base.CanConvertTo(context, destinationType);
         }
-    }    
+    }
 }


### PR DESCRIPTION
Adds an option to choose how you want to set the den index 
- DefeatedDen
Will set the index when you beat a den
- PreInjected
Will set the index to the den with a seed matching one from your list