### PR TITLE
[TradeCord] `$list <species>` fix for with non-alphanumeric characters

### DIFF
--- a/SysBot.Pokemon/TradeCord/TradeCordDB.cs
+++ b/SysBot.Pokemon/TradeCord/TradeCordDB.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Collections.Frozen;
 using PKHeX.Core;
 using PKHeX.Core.AutoMod;
 using static PKHeX.Core.AutoMod.Aesthetics;
@@ -666,6 +667,38 @@ namespace SysBot.Pokemon
             return name;
         }
 
+        protected Species ParseSpeciesFromSanitizedLabel(string label)
+        {
+            var speciesWithDash = ((IReadOnlyList<string>)[
+                "Nidoran-M", "Nidoran-F", "Porygon-Z",
+                "Jangmo-o", "Hakamo-o", "Kommo-o",
+                "Wo-Chien", "Chien-Pao", "Ting-Lu", "Chi-Yu"
+            ]).ToFrozenSet<string>;
+            var speciesWithSpace = ((IReadOnlyList<string>)[
+                "Mr. Mime", "Mime Jr.",
+                "Tapu Koko", "Tapu Lele", "Tapu Bulu", "Tapu Fini",
+                "Mr. Rime",
+                "Great Tusk", "Scream Tail", "Brute Bonnet", "Flutter Mane",
+                "Slither Wing", "Sandy Shocks", "Iron Treads", "Iron Bundle",
+                "Iron Hands", "Iron Jugulis", "Iron Moth", "Iron Thorns",
+                "Roaring Moon", "Iron Valiant",
+                "Walking Wake", "Iron Leaves",
+                "Gouging Fire", "Raging Bolt", "Iron Boulder", "Iron Crown"
+            ]).ToFrozenSet<string>;
+
+            if (label.Contains('’')) // For Farfetch’d and Sirfetch’d
+            {
+                label = label.Where((char x) => x != '’');
+            }
+            else if (speciesWithDash.Contains(label) || speciesWithSpace.Contains(label))
+            {
+                label = label.Where(char.IsLetterOrDigit);
+            }
+
+            bool speciesAndForm = label.Contains('-');
+            return TradeExtensions<T>.EnumParse<Species>(speciesAndForm ? label.Split('-')[0] : label);
+        }
+
         protected bool CanGenerateEgg(ref TCUser user, out IReadOnlyList<EvoCriteria> criteria, out int[] balls, out bool update)
         {
             update = false;
@@ -782,8 +815,8 @@ namespace SysBot.Pokemon
                 var formIDs = Dex[Rng.SpeciesRNG].ToArray();
                 form = 255;
 
-                //if (settings.PokeEventType is PokeEventType.EventPoke)
-                    //mg = MysteryGiftRng(settings);
+                // if (settings.PokeEventType is PokeEventType.EventPoke)
+                    // mg = MysteryGiftRng(settings);
                 if ((int)settings.PokeEventType <= 17)
                 {
                     for (int i = 0; i < formIDs.Length; i++)
@@ -809,8 +842,8 @@ namespace SysBot.Pokemon
                     BaseCanBeEgg(Rng.SpeciesRNG, 0, out _, out ushort baseSpecies);
                     Rng.SpeciesRNG = baseSpecies;
                 }
-                //else if (settings.PokeEventType is PokeEventType.CottonCandy)
-                   // form = formIDs[Random.Next(formIDs.Length)];
+                // else if (settings.PokeEventType is PokeEventType.CottonCandy)
+                    // form = formIDs[Random.Next(formIDs.Length)];
 
                 match = settings.PokeEventType switch
                 {
@@ -833,7 +866,7 @@ namespace SysBot.Pokemon
 
         private bool IsCottonCandy(ushort species, byte form)
         {
-            var color = (PersonalColor)(Game is GameVersion.SWSH ? PersonalTable.SWSH.GetFormEntry(species, form).Color : Game is GameVersion.SV ? PersonalTable.SV.GetFormEntry(species, form).Color : 
+            var color = (PersonalColor)(Game is GameVersion.SWSH ? PersonalTable.SWSH.GetFormEntry(species, form).Color : Game is GameVersion.SV ? PersonalTable.SV.GetFormEntry(species, form).Color :
                 PersonalTable.BDSP.GetFormEntry(species, form).Color);
             return (ShinyMap[(Species)species] is PersonalColor.Blue or PersonalColor.Red or PersonalColor.Pink or PersonalColor.Purple or PersonalColor.Yellow) &&
                 (color is PersonalColor.Blue or PersonalColor.Red or PersonalColor.Pink or PersonalColor.Purple or PersonalColor.Yellow);

--- a/SysBot.Pokemon/TradeCord/TradeCordHelper.cs
+++ b/SysBot.Pokemon/TradeCord/TradeCordHelper.cs
@@ -498,14 +498,14 @@ namespace SysBot.Pokemon
                 string nickname = input;
                 input = ListNameSanitize(input);
                 bool speciesAndForm = input.Contains('-');
-                var speciesID = TradeExtensions<T>.EnumParse<Species>(speciesAndForm ? input.Split('-')[0] : input);
+                var speciesID = ParseSpeciesFromSanitizedLabel(input);
                 bool isSpecies = (ushort)speciesID > 0;
                 bool isBall = Enum.TryParse(input, true, out Ball enumBall);
                 bool isShiny = filters.FirstOrDefault(x => x == "Shiny") != default;
                 bool gmax = filters.FirstOrDefault(x => x == "Gmax") != default;
                 var filterBall = filters.FirstOrDefault(x => x != "Shiny" && x != "Gmax");
-                var strings = GameInfo.GetStrings(LanguageID.English.GetLanguage2CharName()).forms;
-                bool isForm = strings.Contains(input);
+                var formStrings = GameInfo.GetStrings(LanguageID.English.GetLanguage2CharName()).forms;
+                bool isForm = formStrings.Contains(input);
 
                 if (input == "")
                 {
@@ -520,14 +520,14 @@ namespace SysBot.Pokemon
                     return false;
                 }
 
-                var catches = dict.Values.ToList();
+                List<TCCatch> catches = dict.Values.ToList();
                 List<TCCatch> matches = new();
                 matches = filters.Count switch
                 {
-                    1 => catches.FindAll(x => !x.Traded && (isShiny ? x.Shiny : filterBall != default ? x.Ball == filterBall : x.Gmax) && (input == "All" ? x.Species != "" : input == "Legendaries" ? x.Legendary : input == "Events" ? x.Event : input == "Eggs" ? x.Egg : input == "Shinies" ? x.Shiny : speciesAndForm ? x.Species + x.Form == input : isSpecies ? x.Species == input : isForm ? x.Form == $"-{input}" : x.Nickname == nickname)),
-                    2 => catches.FindAll(x => !x.Traded && (isShiny && filterBall != default ? x.Shiny && x.Ball == filterBall : isShiny && gmax ? x.Shiny && x.Gmax : x.Ball == filterBall && x.Gmax) && (input == "All" ? x.Species != "" : input == "Legendaries" ? x.Legendary : input == "Events" ? x.Event : input == "Eggs" ? x.Egg : speciesAndForm ? x.Species + x.Form == input : isSpecies ? x.Species == input : isForm ? x.Form == $"-{input}" : x.Nickname == nickname)),
-                    3 => catches.FindAll(x => !x.Traded && x.Shiny && x.Ball == filterBall && x.Gmax && (input == "All" ? x.Species != "" : input == "Legendaries" ? x.Legendary : input == "Events" ? x.Event : input == "Eggs" ? x.Egg : speciesAndForm ? x.Species + x.Form == input : isSpecies ? x.Species == input : isForm ? x.Form == $"-{input}" : x.Nickname == nickname)),
-                    _ => catches.FindAll(x => !x.Traded && (input == "All" ? x.Species != "" : input == "Legendaries" ? x.Legendary : input == "Events" ? x.Event : input == "Eggs" ? x.Egg : input == "Shinies" ? x.Shiny : input == "Gmax" ? x.Gmax : isBall ? x.Ball == $"{enumBall}" : speciesAndForm ? x.Species + x.Form == input : isSpecies ? x.Species == input : isForm ? x.Form == $"-{input}" : x.Nickname == nickname)),
+                    1 => catches.FindAll((TCCatch x) => !x.Traded && (isShiny ? x.Shiny : filterBall != default ? x.Ball == filterBall : x.Gmax) && (input == "All" ? x.Species != "" : input == "Legendaries" ? x.Legendary : input == "Events" ? x.Event : input == "Eggs" ? x.Egg : input == "Shinies" ? x.Shiny : speciesAndForm ? x.Species + x.Form == input : isSpecies ? x.Species == input : isForm ? x.Form == $"-{input}" : x.Nickname == nickname)),
+                    2 => catches.FindAll((TCCatch x) => !x.Traded && (isShiny && filterBall != default ? x.Shiny && x.Ball == filterBall : isShiny && gmax ? x.Shiny && x.Gmax : x.Ball == filterBall && x.Gmax) && (input == "All" ? x.Species != "" : input == "Legendaries" ? x.Legendary : input == "Events" ? x.Event : input == "Eggs" ? x.Egg : speciesAndForm ? x.Species + x.Form == input : isSpecies ? x.Species == input : isForm ? x.Form == $"-{input}" : x.Nickname == nickname)),
+                    3 => catches.FindAll((TCCatch x) => !x.Traded && x.Shiny && x.Ball == filterBall && x.Gmax && (input == "All" ? x.Species != "" : input == "Legendaries" ? x.Legendary : input == "Events" ? x.Event : input == "Eggs" ? x.Egg : speciesAndForm ? x.Species + x.Form == input : isSpecies ? x.Species == input : isForm ? x.Form == $"-{input}" : x.Nickname == nickname)),
+                    _ => catches.FindAll((TCCatch x) => !x.Traded && (input == "All" ? x.Species != "" : input == "Legendaries" ? x.Legendary : input == "Events" ? x.Event : input == "Eggs" ? x.Egg : input == "Shinies" ? x.Shiny : input == "Gmax" ? x.Gmax : isBall ? x.Ball == $"{enumBall}" : speciesAndForm ? x.Species + x.Form == input : isSpecies ? x.Species == input : isForm ? x.Form == $"-{input}" : x.Nickname == nickname)),
                 };
 
                 if (matches.Count == 0)


### PR DESCRIPTION
Currently, a `$list <species>` command tries to parse the input as a member of the `PKHeX.Core.Species` enum directly. This works fine for most species names, but not when there is a dash ('-'), space ('-'), or apostrophe ('’'; i.e. Farfetch’d or Sirfetch’d). For those species, it fails to parse the enumeration and instead treats the input label as a nickname.

This is fine when the Pokémon in question is not nicknamed, but is more of a pain when the Pokémon is from a language such as French or German where the name does not match the English name. (Also, if a Pokémon such as Farfetch’d or Tapu Koko is nicknamed, even if its language is English, it will not be found by `$list Farfetch'd` or `$list Tapu Koko`.)

Generation 9 introduced many more Pokémon with dashes or spaces, in particular the Ruinous Legendaries and Paradox Pokémon. In particular, Paradox Pokémon are so far the only Pokémon with different species names in Spanish and Italian from the English names. This means `$list Iron Hands` will return only English-language, non-nicknamed Iron Hands (or any Pokémon someone has decided to nickname "Iron Hands", for some reason). It has been known for months that, for example, to find Spanish-language Iron Hands, one must enter `$list Ferropalmas`. Today, I confirmed by nicknaming one of my English Iron Hands "William", that `$list Iron Hands` does not find him after the nickname change (in the currently deployed code).

After this change, `$list Ferropalmas` should still list non-nicknamed Spanish-language Iron Hands, but `$list Iron Hands` should list all of someone's Iron Hands, whatever their language of origin and whatever their nickname.