### PR TITLE
[TradeCord] `$list <species>` fix for with non-alphanumeric characters

### DIFF
--- a/SysBot.Pokemon/TradeCord/TradeCordDB.cs
+++ b/SysBot.Pokemon/TradeCord/TradeCordDB.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Linq;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using PKHeX.Core;
 using PKHeX.Core.AutoMod;
+
 using static PKHeX.Core.AutoMod.Aesthetics;
-using System.Collections.Frozen;
 
 namespace SysBot.Pokemon;
 
@@ -661,7 +662,7 @@ public abstract class TradeCordDatabase<T> : TradeCordBase<T> where T : PKM, new
     protected Species ParseSpeciesFromSanitizedLabel(string label)
     {
         var speciesWithDash = ((IReadOnlyList<string>)[
-                    "Nidoran-M",
+            "Nidoran-M",
             "Nidoran-F",
             "Porygon-Z",
             "Jangmo-o",
@@ -673,8 +674,9 @@ public abstract class TradeCordDatabase<T> : TradeCordBase<T> where T : PKM, new
             "Chi-Yu"
         ]).ToFrozenSet<string>;
         var speciesWithSpace = ((IReadOnlyList<string>)[
-                    "Mr. Mime",
+            "Mr. Mime",
             "Mime Jr.",
+            "Type: Null",
             "Tapu Koko",
             "Tapu Lele",
             "Tapu Bulu",

--- a/SysBot.Pokemon/TradeCord/TradeCordDB.cs
+++ b/SysBot.Pokemon/TradeCord/TradeCordDB.cs
@@ -664,6 +664,7 @@ public abstract class TradeCordDatabase<T> : TradeCordBase<T> where T : PKM, new
         var speciesWithDash = ((IReadOnlyList<string>)[
             "Nidoran-M",
             "Nidoran-F",
+            "Ho-Oh",
             "Porygon-Z",
             "Jangmo-o",
             "Hakamo-o",

--- a/SysBot.Pokemon/TradeCord/TradeCordHelper.cs
+++ b/SysBot.Pokemon/TradeCord/TradeCordHelper.cs
@@ -508,7 +508,7 @@ public class TradeCordHelper<T> : TradeCordDatabase<T> where T : PKM, new()
             string nickname = input;
             input = ListNameSanitize(input);
             bool speciesAndForm = input.Contains('-');
-            var speciesID = TradeExtensions<T>.EnumParse<Species>(speciesAndForm ? input.Split('-')[0] : input); //var speciesID = ParseSpeciesFromSanitizedLabel(input);
+            Species speciesID = ParseSpeciesFromSanitizedLabel(input);
             bool isSpecies = (ushort)speciesID > 0;
             bool isBall = Enum.TryParse(input, true, out Ball enumBall);
             bool isShiny = filters.FirstOrDefault(x => x == "Shiny") != default;
@@ -531,14 +531,14 @@ public class TradeCordHelper<T> : TradeCordDatabase<T> where T : PKM, new()
                 return false;
             }
 
-            var catches = dict.Values.ToList();
+            List<TCCatch> catches = dict.Values.ToList();
             List<TCCatch> matches = [];
             matches = filters.Count switch
             {
-                1 => catches.FindAll(x => !x.Traded && (isShiny ? x.Shiny : filterBall != default ? x.Ball == filterBall : x.Gmax) && (input == "All" ? x.Species != "" : input == "Legendaries" ? x.Legendary : input == "Events" ? x.Event : input == "Eggs" ? x.Egg : input == "Shinies" ? x.Shiny : speciesAndForm ? x.Species + x.Form == input : isSpecies ? x.Species == input : isForm ? x.Form == $"-{input}" : x.Nickname == nickname)),
-                2 => catches.FindAll(x => !x.Traded && (isShiny && filterBall != default ? x.Shiny && x.Ball == filterBall : isShiny && gmax ? x.Shiny && x.Gmax : x.Ball == filterBall && x.Gmax) && (input == "All" ? x.Species != "" : input == "Legendaries" ? x.Legendary : input == "Events" ? x.Event : input == "Eggs" ? x.Egg : speciesAndForm ? x.Species + x.Form == input : isSpecies ? x.Species == input : isForm ? x.Form == $"-{input}" : x.Nickname == nickname)),
-                3 => catches.FindAll(x => !x.Traded && x.Shiny && x.Ball == filterBall && x.Gmax && (input == "All" ? x.Species != "" : input == "Legendaries" ? x.Legendary : input == "Events" ? x.Event : input == "Eggs" ? x.Egg : speciesAndForm ? x.Species + x.Form == input : isSpecies ? x.Species == input : isForm ? x.Form == $"-{input}" : x.Nickname == nickname)),
-                _ => catches.FindAll(x => !x.Traded && (input == "All" ? x.Species != "" : input == "Legendaries" ? x.Legendary : input == "Events" ? x.Event : input == "Eggs" ? x.Egg : input == "Shinies" ? x.Shiny : input == "Gmax" ? x.Gmax : isBall ? x.Ball == $"{enumBall}" : speciesAndForm ? x.Species + x.Form == input : isSpecies ? x.Species == input : isForm ? x.Form == $"-{input}" : x.Nickname == nickname)),
+                1 => catches.FindAll((TCCatch x) => !x.Traded && (isShiny ? x.Shiny : filterBall != default ? x.Ball == filterBall : x.Gmax) && (input == "All" ? x.Species != "" : input == "Legendaries" ? x.Legendary : input == "Events" ? x.Event : input == "Eggs" ? x.Egg : input == "Shinies" ? x.Shiny : speciesAndForm ? x.Species + x.Form == input : isSpecies ? x.Species == input : isForm ? x.Form == $"-{input}" : x.Nickname == nickname)),
+                2 => catches.FindAll((TCCatch x) => !x.Traded && (isShiny && filterBall != default ? x.Shiny && x.Ball == filterBall : isShiny && gmax ? x.Shiny && x.Gmax : x.Ball == filterBall && x.Gmax) && (input == "All" ? x.Species != "" : input == "Legendaries" ? x.Legendary : input == "Events" ? x.Event : input == "Eggs" ? x.Egg : speciesAndForm ? x.Species + x.Form == input : isSpecies ? x.Species == input : isForm ? x.Form == $"-{input}" : x.Nickname == nickname)),
+                3 => catches.FindAll((TCCatch x) => !x.Traded && x.Shiny && x.Ball == filterBall && x.Gmax && (input == "All" ? x.Species != "" : input == "Legendaries" ? x.Legendary : input == "Events" ? x.Event : input == "Eggs" ? x.Egg : speciesAndForm ? x.Species + x.Form == input : isSpecies ? x.Species == input : isForm ? x.Form == $"-{input}" : x.Nickname == nickname)),
+                _ => catches.FindAll((TCCatch x) => !x.Traded && (input == "All" ? x.Species != "" : input == "Legendaries" ? x.Legendary : input == "Events" ? x.Event : input == "Eggs" ? x.Egg : input == "Shinies" ? x.Shiny : input == "Gmax" ? x.Gmax : isBall ? x.Ball == $"{enumBall}" : speciesAndForm ? x.Species + x.Form == input : isSpecies ? x.Species == input : isForm ? x.Form == $"-{input}" : x.Nickname == nickname)),
             };
 
             if (matches.Count == 0)
@@ -687,7 +687,7 @@ public class TradeCordHelper<T> : TradeCordDatabase<T> where T : PKM, new()
             bool isParadox = IsParadox((ushort)speciesID);
             string ballStr = ball != Ball.None ? $"Pokémon in {ball} Ball" : "";
             string generalOutput = input == "Shinies" ? "shiny Pokémon" : input == "Events" ? "non-shiny event Pokémon" : input == "Legendaries" ? "non-shiny legendary Pokémon" : input == "Paradoxes" ? "non-shiny paradox Pokémon" : ball != Ball.None ? ballStr : $"non-shiny {input}";
-            string exclude = ball is Ball.Cherish || input == "Events" ? ", legendaries, paradoxes" : input == "Legendaries" ? ", events, paradoxes," : input == "Paradoxes" ? ", events, legendaries," : $", events,{(isLegend ? "" : " legendaries,")}{(isParadox ? "" : " paradoxes,")}"; 
+            string exclude = ball is Ball.Cherish || input == "Events" ? ", legendaries, paradoxes" : input == "Legendaries" ? ", events, paradoxes," : input == "Paradoxes" ? ", events, legendaries," : $", events,{(isLegend ? "" : " legendaries,")}{(isParadox ? "" : " paradoxes,")}";
             result.Message = input == "" ? "Every non-shiny Pokémon was released, excluding Ditto, favorites, events, buddy, legendaries, and those in daycare." : $"Every {generalOutput} was released, excluding favorites, buddy{exclude} and those in daycare.";
             return true;
         }
@@ -918,7 +918,7 @@ public class TradeCordHelper<T> : TradeCordDatabase<T> where T : PKM, new()
             bool isLegend = IsLegendaryOrMythical(pk.Species);
 
             var names = CatchValues.Replace(" ", "").Split(',');
-            var obj = new object[] { m_user.UserInfo.UserID, newID, match.Shiny, match.Ball, match.Nickname, match.Species, match.Form, match.Egg, false, false, isLegend, match.Event, match.Gmax }; 
+            var obj = new object[] { m_user.UserInfo.UserID, newID, match.Shiny, match.Ball, match.Nickname, match.Species, match.Form, match.Egg, false, false, isLegend, match.Event, match.Gmax };
             result.SQLCommands.Add(DBCommandConstructor("catches", CatchValues, "", names, obj, SQLTableContext.Insert));
 
             names = BinaryCatchesValues.Replace(" ", "").Split(',');
@@ -2315,7 +2315,7 @@ public class TradeCordHelper<T> : TradeCordDatabase<T> where T : PKM, new()
         int[] array = result.User.Catches.Select(x => x.Value.ID).ToArray();
         array = array.OrderBy(x => x).ToArray();
         index = Indexing(array);
-        result.User.Catches.Add(index, new() { Species = speciesName, Nickname = pk.Nickname, Ball = $"{(Ball)pk.Ball}", Egg = pk.IsEgg, Form = form, ID = index, Shiny = pk.IsShiny, Traded = false, Favorite = false, Legendary = isLegend, Event = pk.FatefulEncounter, Gmax = canGmax});
+        result.User.Catches.Add(index, new() { Species = speciesName, Nickname = pk.Nickname, Ball = $"{(Ball)pk.Ball}", Egg = pk.IsEgg, Form = form, ID = index, Shiny = pk.IsShiny, Traded = false, Favorite = false, Legendary = isLegend, Event = pk.FatefulEncounter, Gmax = canGmax });
 
         var names = CatchValues.Replace(" ", "").Replace("-", "").Split(',');
         var obj = new object[] { result.User.UserInfo.UserID, index, pk.IsShiny, $"{(Ball)pk.Ball}", pk.Nickname, speciesName, form, pk.IsEgg, false, false, isLegend, pk.FatefulEncounter, canGmax, isParadox };


### PR DESCRIPTION
Currently, a `$list <species>` command tries to parse the input as a member of the `PKHeX.Core.Species` enum directly. This works fine for most species names, but not when there is a dash ('-'), space ('-'), or apostrophe ('’'; i.e. Farfetch’d or Sirfetch’d). For those species, it fails to parse the enumeration and instead treats the input label as a nickname.

This is fine when the Pokémon in question is not nicknamed, but is more of a pain when the Pokémon is from a language such as French or German where the name does not match the English name. (Also, if a Pokémon such as Farfetch’d or Tapu Koko is nicknamed, even if its language is English, it will not be found by `$list Farfetch'd` or `$list Tapu Koko`.)

Generation 9 introduced many more Pokémon with dashes or spaces, in particular the Ruinous Legendaries and Paradox Pokémon. In particular, Paradox Pokémon are so far the only Pokémon with different species names in Spanish and Italian from the English names. This means `$list Iron Hands` will return only English-language, non-nicknamed Iron Hands (or any Pokémon someone has decided to nickname "Iron Hands", for some reason). It has been known for months that, for example, to find Spanish-language Iron Hands, one must enter `$list Ferropalmas`. Today, I confirmed by nicknaming one of my English Iron Hands "William", that `$list Iron Hands` does not find him after the nickname change (in the currently deployed code).

After this change, `$list Ferropalmas` should still list non-nicknamed Spanish-language Iron Hands, but `$list Iron Hands` should list all of someone's Iron Hands, whatever their language of origin and whatever their nickname.