### PR TITLE
[TradeCord] Show Pokémon language in $info and $buddy commands

### DIFF
--- a/SysBot.Pokemon.Discord/Commands/Extra/TradeCordModule.cs
+++ b/SysBot.Pokemon.Discord/Commands/Extra/TradeCordModule.cs
@@ -746,12 +746,13 @@ public class TradeCordModule<T> : ModuleBase<SocketCommandContext> where T : PKM
         var form = TradeExtensions<T>.FormOutput(result.Poke.Species, result.Poke.Form, out _).Replace("-", "");
         var lvlProgress = (Experience.GetEXPToLevelUpPercentage(result.Poke.CurrentLevel, result.Poke.EXP, result.Poke.PersonalInfo.EXPGrowth) * 100.0).ToString("N1");
         msg = $"\n**Nickname:** {result.User.Buddy.Nickname}" +
-              $"\n**Species:** {SpeciesName.GetSpeciesNameGeneration(result.Poke.Species, 2, 8)} {GameInfo.GenderSymbolUnicode[result.Poke.Gender].Replace("-", "")}" +
+              $"\n**Species:** {SpeciesName.GetSpeciesNameGeneration(result.Poke.Species, 2, 9)} {GameInfo.GenderSymbolUnicode[result.Poke.Gender].Replace("-", "")}" +
               $"\n**Form:** {(form == string.Empty ? "-" : form)}" +
               $"\n**Gigantamax:** {(canGmax ? "Yes" : "No")}" +
               $"\n**Ability:** {result.User.Buddy.Ability}" +
               $"\n**Level:** {result.Poke.CurrentLevel}" +
               $"\n**Friendship:** {result.Poke.CurrentFriendship}" +
+              $"\n**Language:** {result.Poke.Language}" +
               $"\n**Held item:** {GameInfo.Strings.itemlist[result.Poke.HeldItem]}" +
               $"\n**Time of day:** {TradeCordHelper<T>.TimeOfDayString(result.User.UserInfo.TimeZoneOffset, false)}" +
               $"{(!result.Poke.IsEgg && result.Poke.CurrentLevel < 100 ? $"\n**Progress to next level:** {lvlProgress}%" : "")}";

--- a/SysBot.Pokemon.Discord/Helpers/ReusableActions.cs
+++ b/SysBot.Pokemon.Discord/Helpers/ReusableActions.cs
@@ -92,7 +92,7 @@ public static class ReusableActions
                 mark = $"\nPokémon has the **{encmark.ToString().Replace("Mark", "")} Mark**!";
         }
 
-        var extra = new string[] { $"\nOT: {pkm.OriginalTrainerName}", $"\nTID: {pkm.GetDisplayTID()}", $"\nSID: {pkm.GetDisplaySID()}", $"{(pkm.IsEgg ? "\nIsEgg: Yes" : "")}", $"\n{mark.Trim()}" };
+        var extra = new string[] { $"\nOT: {pkm.OriginalTrainerName}", $"\nTID: {pkm.GetDisplayTID()}", $"\nSID: {pkm.GetDisplaySID()}", $"\nLanguage: {pkm.Language}", $"{(pkm.IsEgg ? "\nIsEgg: Yes" : "")}", $"\n{mark.Trim()}" };
         newShowdown.InsertRange(1, extra);
         return Format.Code(string.Join("", newShowdown).Trim());
     }


### PR DESCRIPTION
Adjust the command output of `GetFormattedShowdownText()` and `TradeCordBuddy()` to also show the language which the relevant Pokémon has