### PR TITLE
[Tradecord] Display name of language, not enumerated language ID

### DIFF
--- a/SysBot.Pokemon.Discord/Commands/Extra/TradeCordModule.cs
+++ b/SysBot.Pokemon.Discord/Commands/Extra/TradeCordModule.cs
@@ -746,12 +746,13 @@ public class TradeCordModule<T> : ModuleBase<SocketCommandContext> where T : PKM
         var form = TradeExtensions<T>.FormOutput(result.Poke.Species, result.Poke.Form, out _).Replace("-", "");
         var lvlProgress = (Experience.GetEXPToLevelUpPercentage(result.Poke.CurrentLevel, result.Poke.EXP, result.Poke.PersonalInfo.EXPGrowth) * 100.0).ToString("N1");
         msg = $"\n**Nickname:** {result.User.Buddy.Nickname}" +
-              $"\n**Species:** {SpeciesName.GetSpeciesNameGeneration(result.Poke.Species, 2, 8)} {GameInfo.GenderSymbolUnicode[result.Poke.Gender].Replace("-", "")}" +
+              $"\n**Species:** {SpeciesName.GetSpeciesNameGeneration(result.Poke.Species, 2, 9)} {GameInfo.GenderSymbolUnicode[result.Poke.Gender].Replace("-", "")}" +
               $"\n**Form:** {(form == string.Empty ? "-" : form)}" +
               $"\n**Gigantamax:** {(canGmax ? "Yes" : "No")}" +
               $"\n**Ability:** {result.User.Buddy.Ability}" +
               $"\n**Level:** {result.Poke.CurrentLevel}" +
               $"\n**Friendship:** {result.Poke.CurrentFriendship}" +
+              $"\n**Language:** {(LanguageID)result.Poke.Language}" +
               $"\n**Held item:** {GameInfo.Strings.itemlist[result.Poke.HeldItem]}" +
               $"\n**Time of day:** {TradeCordHelper<T>.TimeOfDayString(result.User.UserInfo.TimeZoneOffset, false)}" +
               $"{(!result.Poke.IsEgg && result.Poke.CurrentLevel < 100 ? $"\n**Progress to next level:** {lvlProgress}%" : "")}";

--- a/SysBot.Pokemon.Discord/Helpers/ReusableActions.cs
+++ b/SysBot.Pokemon.Discord/Helpers/ReusableActions.cs
@@ -92,16 +92,16 @@ public static class ReusableActions
                 mark = $"\nPokémon has the **{encmark.ToString().Replace("Mark", "")} Mark**!";
         }
 
-        var extra = new string[] { $"\nOT: {pkm.OriginalTrainerName}", $"\nTID: {pkm.GetDisplayTID()}", $"\nSID: {pkm.GetDisplaySID()}", $"{(pkm.IsEgg ? "\nIsEgg: Yes" : "")}", $"\n{mark.Trim()}" };
-        newShowdown.InsertRange(1, extra);
+        var extra = new string[] { $"\nOT: {pkm.OriginalTrainerName}", $"\nTID: {pkm.GetDisplayTID()}", $"\nSID: {pkm.GetDisplaySID()}", $"\nLanguage:{(LanguageID)pkm.Language}"; $"{(pkm.IsEgg ? "\nIsEgg: Yes" : "")}", $"\n{mark.Trim()}" };
+    newShowdown.InsertRange(1, extra);
         return Format.Code(string.Join("", newShowdown).Trim());
     }
 
-    public static List<string> GetListFromString(string str)
-    {
-        // Extract comma separated list
-        return str.Split(new[] { ",", ", ", " " }, StringSplitOptions.RemoveEmptyEntries).ToList();
-    }
+public static List<string> GetListFromString(string str)
+{
+    // Extract comma separated list
+    return str.Split(new[] { ",", ", ", " " }, StringSplitOptions.RemoveEmptyEntries).ToList();
+}
 
-    public static string StripCodeBlock(string str) => str.Replace("`\n", "").Replace("\n`", "").Replace("`", "").Trim();
+public static string StripCodeBlock(string str) => str.Replace("`\n", "").Replace("\n`", "").Replace("`", "").Trim();
 }


### PR DESCRIPTION
My earlier PR was technically correct, except now it's displaying "Language: 7" or "Language: 8" instead of "Language: Spanish" or "Language: Korean", respectively