### PR TITLE
[Tradecord] Attempt to fix breeding of unevolved Pokémon

### DIFF
--- a/SysBot.Pokemon/TradeCord/TradeCordDB.cs
+++ b/SysBot.Pokemon/TradeCord/TradeCordDB.cs
@@ -805,12 +805,12 @@ public abstract class TradeCordDatabase<T> : TradeCordBase<T> where T : PKM, new
                 list[i].Form = 0;
 
             var tree = EvolutionTree.GetEvolutionTree(list[i].Context); // Obtain the correct evolution tree for the context
-            var preEvos = tree.Reverse.GetPreEvolutions(list[i].Species, list[i].Form).Where(x => x.Form == form).ToList(); // Obtain the reverse evolution paths
-            var filteredPreEvos = preEvos.ToList();
-            if (!filteredPreEvos.Any())
-                continue;
-            var evo = filteredPreEvos.LastOrDefault();
-            criteriaList.Add(new EvoCriteria { Species = evo.Species, Form = evo.Form });
+            var baseForm = tree.GetBaseSpeciesForm(list[i].Species, list[i].Form);
+            if (baseForm.Form != form)
+            {
+                baseForm.Form = form;
+            }
+            criteriaList.Add(new EvoCriteria { Species = baseForm.Species, Form = baseForm.Form });
         }
         return criteriaList;
     }


### PR DESCRIPTION
This should be tested. I'm not able to test it on my own, but I discovered the function `[EvolutionNetwork::GetBaseSpeciesForm()](https://github.com/kwsch/PKHeX/blob/e1b964ad64b3ab7b1e36a68956ec2b0c79ddbc13/PKHeX.Core/Legality/Evolutions/IEvolutionNetwork.cs#L70-L76)` in PKHeX which looks like what we want.

To use this in conjunction with my other PRs such as #47 shouldn't require much if any merging. In that case, just check that `byte form = BreedForm(list[i])` (which function doesn't exist in this branch).