### PR TITLE
[Tradecord] Add SV DLC evolution items

### DIFF
--- a/SysBot.Pokemon/TradeCord/HelperEnums.cs
+++ b/SysBot.Pokemon/TradeCord/HelperEnums.cs
@@ -789,7 +789,10 @@ public enum TCItems
     GalaricaCuff = 1582,
     GalaricaWreath = 1592,
 
+    PeatBlock = 1692,
+
     GriseousCore = 1779,
+
     MaliciousArmor = 1861,
     GimmighoulCoin = 2137,
     AuspiciousArmor = 2344,

--- a/SysBot.Pokemon/TradeCord/HelperEnums.cs
+++ b/SysBot.Pokemon/TradeCord/HelperEnums.cs
@@ -794,6 +794,11 @@ public enum TCItems
     GimmighoulCoin = 2137,
     AuspiciousArmor = 2344,
     LeadersCrest = 2345,
+
+    SyrupyApple = 2402,
+    UnremarkableTeacup = 2403,
+    MasterpieceTeacup = 2404,
+    MetalAlloy = 2482,
 }
 
 public enum AlcremieForms

--- a/SysBot.Pokemon/TradeCord/TradeCordBase.cs
+++ b/SysBot.Pokemon/TradeCord/TradeCordBase.cs
@@ -1441,6 +1441,7 @@ public abstract class TradeCordBase<T> where T : PKM, new()
             (ushort)Slowbro when form > 0 => TCItems.GalaricaCuff,
             (ushort)Slowking when form > 0 => TCItems.GalaricaWreath,
             (ushort)Slowking or (ushort)Politoed => TCItems.KingsRock,
+            (ushort)Ursuluna => TCItems.PeatBlock,
 
             // Held item
             (ushort)Kingdra => TCItems.DragonScale,

--- a/SysBot.Pokemon/TradeCord/TradeCordBase.cs
+++ b/SysBot.Pokemon/TradeCord/TradeCordBase.cs
@@ -1453,7 +1453,7 @@ public abstract class TradeCordBase<T> where T : PKM, new()
             (ushort)Huntail => TCItems.DeepSeaTooth,
             (ushort)Gorebyss => TCItems.DeepSeaScale,
             (ushort)Rhyperior => TCItems.Protector,
-            (ushort)Weavile => TCItems.RazorClaw,
+            (ushort)Weavile or (ushort)Sneasler => TCItems.RazorClaw,
             (ushort)Dusknoir => TCItems.ReaperCloth,
             (ushort)Aromatisse => TCItems.Sachet,
             (ushort)Porygon2 => TCItems.Upgrade,
@@ -1469,6 +1469,9 @@ public abstract class TradeCordBase<T> where T : PKM, new()
             (ushort)Ceruledge => TCItems.MaliciousArmor,
             (ushort)Gholdengo => TCItems.GimmighoulCoin,
             (ushort)Kingambit => TCItems.LeadersCrest,
+            (ushort)Dipplin => TCItems.SyrupyApple,
+            (ushort)Sinistcha => form == 0 ? TCItems.UnremarkableTeacup : TCItems.MasterpieceTeacup,
+            (ushort)Archaludon => TCItems.MetalAlloy,
 
             _ => TCItems.None,
         };


### PR DESCRIPTION
This PR has two commits.

The first adds the evolution items Syrupy Apple, Unremarkable Teacup, Masterpiece Teacup and Metal Alloy to TradeCord circulation. It further updates the `GetEvoItem()` function to acknowledge these as the evolution items for Applin -> Dipplin, Poltchageist -> Sinistcha, and Duraludon -> Archaludon. (Additionally, it lists Razor Claw as the evolution item for Sneasler; which was previously only listed for Weavile.)

The second commit adds Peat Block and updates `GetEvoItem()` to acknowledge this as the evolution item for Ursaring -> Ursaluna. I thought it wise to include it as a separate commit from the first so it can be tested separately because Peat Blocks are not legally obtainable in S/V. However, TC already includes the item Gimmighoul Coin which cannot be held, and if you try to give it to your buddy via `$giveitem Gimmighoul Coin`, it will fail and Buns will tell you "Oops, something went wrong while giving an item to <buddy>!" I believe this will be the same if you try to give it a Peat Block (and should therefore prevent Peat Blocks from being traded into users' games)--but I am not certain, hence the separate commit.

Note: this PR does not attempt to actually activate evolution. That will probably be a harder fix and will be separate.
