### PR TITLE
[Tradecord SV] Re-enable evolution

### DIFF
--- a/SysBot.Pokemon.Discord/Commands/Extra/TradeCordModule.cs
+++ b/SysBot.Pokemon.Discord/Commands/Extra/TradeCordModule.cs
@@ -803,10 +803,7 @@ public class TradeCordModule<T> : ModuleBase<SocketCommandContext> where T : PKM
     [RequireQueueRole(nameof(DiscordManager.RolesTradeCord))]
     public async Task TradeCordEvolution([Remainder][Summary("Usable item or Alcremie form.")] string input = "")
     {
-        await ReplyAsync("To further bring the community together, evolutions has currently been turned off. ").ConfigureAwait(false);
-        return;
-
-        /*string name = $"{Context.User.Username}'s Evolution";
+        string name = $"{Context.User.Username}'s Evolution";
         if (!TradeCordParanoiaChecks(out string msg))
         {
             await Util.EmbedUtil(Context, name, msg).ConfigureAwait(false);
@@ -835,7 +832,7 @@ public class TradeCordModule<T> : ModuleBase<SocketCommandContext> where T : PKM
             Author = author,
         }.WithFooter(x => { x.Text = flavorText; x.IconUrl = "https://i.imgur.com/nXNBrlr.png"; });
 
-        await Context.Channel.SendMessageAsync(null, false, embed: embed.Build()).ConfigureAwait(false);*/
+        await Context.Channel.SendMessageAsync(null, false, embed: embed.Build()).ConfigureAwait(false);
     }
 
     [Command("TradeCordGiveItem")]

--- a/SysBot.Pokemon/TradeCord/TradeCordBase.cs
+++ b/SysBot.Pokemon/TradeCord/TradeCordBase.cs
@@ -1346,6 +1346,55 @@ public abstract class TradeCordBase<T> where T : PKM, new()
         return array.Where(x => x > 0).Distinct().OrderBy(x => x).Any(x => x != (i += 1)) ? i : i + 1;
     }
 
+    private bool IsLevelUpEvolutionVariant(EvolutionType evoType)
+    {
+        return evoType switch
+        {
+            EvolutionType.LevelUp or
+            EvolutionType.LevelUpATK or
+            EvolutionType.LevelUpAeqD or
+            EvolutionType.LevelUpDEF or
+            EvolutionType.LevelUpBeauty or
+            EvolutionType.LevelUpElectric or EvolutionType.LevelUpForest or
+            EvolutionType.LevelUpCold or EvolutionType.LevelUpInverted or
+            EvolutionType.LevelUpWeather or EvolutionType.LevelUpSummit or
+            EvolutionType.LevelUpWithTeammate or
+            EvolutionType.LevelUpWalkStepsWith or
+            EvolutionType.LevelUpUnionCircle or
+            EvolutionType.LevelUpInBattleEC100 or
+            EvolutionType.LevelUpInBattleECElse or
+            EvolutionType.LevelUpDefeatEquals or
+            EvolutionType.LevelUpUseMoveSpecial or
+            EvolutionType.LevelUpKnowMoveECElse or
+            EvolutionType.LevelUpKnowMoveEC100 or
+            EvolutionType.LevelUpRecoilDamageMale or
+            EvolutionType.LevelUpRecoilDamageFemale or
+            EvolutionType.UseMoveAgileStyle or
+            EvolutionType.UseMoveStrongStyle
+            // I'm not sure whether EvolutionType.Hisui should go here.
+            // I'm leaning no because it might cause ambiguity for things with
+            // Hisuian form evolutions.
+                => true,
+            _ => false
+        };
+    }
+
+    private bool IsItemEvolutionVariant(EvolutionType evoType)
+    {
+        return evoType switch
+        {
+            EvolutionType.TradeHeldItem or EvolutionType.UseItem or
+            EvolutionType.UseItemFemale or EvolutionType.UseItemMale or
+            EvolutionType.LevelUpHeldItemDay or
+            EvolutionType.LevelUpHeldItemNight or
+            EvolutionType.Spin or
+            EvolutionType.UseItemFullMoon
+                => true,
+            _ => false
+        };
+    }
+
+
     private List<EvolutionTemplate> EvolutionRequirements()
     {
         var sav = AutoLegalityWrapper.GetTrainerInfo<T>();
@@ -1385,12 +1434,15 @@ public abstract class TradeCordBase<T> where T : PKM, new()
                         TCItems item = TCItems.None;
                         bool baseSp = c - 1 < 0;
 
-                        if (evoType is EvolutionType.LevelUpElectric or EvolutionType.LevelUpForest or EvolutionType.LevelUpCold or EvolutionType.LevelUpSummit or EvolutionType.LevelUpWeather or EvolutionType.LevelUpWithTeammate or EvolutionType.LevelUpBeauty)
+                        if (IsLevelUpEvolutionVariant(evoType))
+                        {
                             evoType = EvolutionType.LevelUp;
+                        }
 
-                        if (evoType is EvolutionType.TradeHeldItem or EvolutionType.UseItem or EvolutionType.UseItemFemale or EvolutionType.UseItemMale or EvolutionType.LevelUpHeldItemDay or EvolutionType.LevelUpHeldItemNight or EvolutionType.Spin)
+                        if (IsItemEvolutionVariant(evoType))
+                        {
                             item = GetEvoItem((ushort)(baseSp ? 0 : preEvos[c - 1].Species), f);
-
+                        }
                         var template = new EvolutionTemplate
                         {
                             Species = preEvos[c].Species,
@@ -1409,6 +1461,12 @@ public abstract class TradeCordBase<T> where T : PKM, new()
                             template.EvolvesAtLevel = 24;
                         else if (preEvos[c].Species is (ushort)Ambipom)
                             template.EvolvesAtLevel = 31;
+                        else if (preEvos[c].Species is (ushort)Gimmighoul)
+                            template.EvolvesAtLevel = 6;
+                        else if (preEvos[c].Species is (ushort)Pawmo)
+                            template.EvolvesAtLevel = 19;
+                        else if (preEvos[c].Species is (ushort)Bramblin or (ushort)Rellor)
+                            template.EvolvesAtLevel = 2;
 
                         list.Add(template);
                     }

--- a/SysBot.Pokemon/TradeCord/TradeCordDB.cs
+++ b/SysBot.Pokemon/TradeCord/TradeCordDB.cs
@@ -581,6 +581,12 @@ public abstract class TradeCordDatabase<T> : TradeCordBase<T> where T : PKM, new
                 (ushort)Species.Grapploct when !pk.RelearnMoves.ToList().Contains(269) => 269, // Taunt
                 (ushort)Species.Lickilicky when !pk.RelearnMoves.ToList().Contains(205) => 205, // Rollout
                 (ushort)Species.Ambipom when !pk.RelearnMoves.ToList().Contains(458) => 458, // Double Hit
+                (ushort)Species.Wyrdeer when !pk.RelearnMoves.ToList().Contains(Move.PsyshieldBash) => (ushort)Move.PsyshieldBash,
+                (ushort)Species.Overqwil when !pk.RelearnMoves.ToList().Contains(Move.BarbBarrage) => (ushort)Move.BarbBarrage,
+                (ushort)Species.Dudunsparce when !pk.RelearnMoves.ToList().Contains(Move.HyperDrill) => (ushort)Move.HyperDrill,
+                (ushort)Species.Farigiraf when !pk.RelearnMoves.ToList().Contains(Move.TwinBeam) => (ushort)Move.TwinBeam,
+                (ushort)Species.Annihilape when !pk.RelearnMoves.ToList().Contains(Move.RageFist) => (ushort)Move.RageFist,
+                (ushort)Species.Hydrapple when !pk.RelearnMoves.ToList().Contains(Move.DragonCheer) => (ushort)Move.DragonCheer,
                 _ => 0,
             };
 
@@ -605,7 +611,7 @@ public abstract class TradeCordDatabase<T> : TradeCordBase<T> where T : PKM, new
             (ushort)Species.Eevee when item <= 0 => evoList.Find(x => x.DayTime == tod),
             (ushort)Species.Toxel => TradeExtensions<T>.LowKey.Contains((int)pk.Nature) ? evoList.Find(x => x.EvolvedForm is 1) : evoList.Find(x => x.EvolvedForm is 0),
             (ushort)Species.Milcery when alcremieForm >= 0 => evoList.Find(x => x.EvolvedForm == alcremieForm),
-            (ushort)Species.Cosmoem => pk.Version is (GameVersion)45 ? evoList.Find(x => x.EvolvesInto is (ushort)Species.Lunala) : evoList.Find(x => x.EvolvesInto is (ushort)Species.Solgaleo),
+            (ushort)Species.Cosmoem => (pk.Version is GameVersion.SH or GameVersion.VL) ? evoList.Find(x => x.EvolvesInto is (ushort)Species.Lunala) : evoList.Find(x => x.EvolvesInto is (ushort)Species.Solgaleo),
             (ushort)Species.Nincada => evoList.Find(x => x.EvolvesInto is (ushort)Species.Ninjask),
             (ushort)Species.Espurr => evoList.Find(x => x.EvolvedForm == (pk.Gender is (int)Gender.Male ? 0 : 1)),
             (ushort)Species.Combee => evoList.Find(x => x.EvolvesInto == (pk.Gender is (int)Gender.Male ? -1 : (ushort)Species.Vespiquen)),
@@ -616,6 +622,9 @@ public abstract class TradeCordDatabase<T> : TradeCordBase<T> where T : PKM, new
             (ushort)Species.Rockruff when pk.Form is 1 => evoList.Find(x => x.EvolvedForm is 2), // Dusk
             (ushort)Species.Rockruff => evoList.Find(x => x.DayTime == tod),
             (ushort)Species.Wurmple => GetWurmpleEvo(pk, evoList),
+            (ushort)Species.Basculin when pk.Form is 2 => evoList.Find(x => x.EvolvedForm == (pk.Gender is (int)Gender.Male ? 0 : 1)),
+            (ushort)Species.Tandemaus => evoList.Find(x => x.EvolvedForm == (pk.EncryptionConstant % 100 == 0) ? 0 : 1),
+            (ushort)Species.Dunsparce => evoList.Find(x => x.EvolvedForm == (pk.EncryptionConstant % 100 == 0) ? 1 : 0),
             _ => evoList.Find(x => x.BaseForm == pk.Form),
         };
         return result!;

--- a/SysBot.Pokemon/TradeCord/TradeCordHelper.cs
+++ b/SysBot.Pokemon/TradeCord/TradeCordHelper.cs
@@ -687,7 +687,7 @@ public class TradeCordHelper<T> : TradeCordDatabase<T> where T : PKM, new()
             bool isParadox = IsParadox((ushort)speciesID);
             string ballStr = ball != Ball.None ? $"Pokémon in {ball} Ball" : "";
             string generalOutput = input == "Shinies" ? "shiny Pokémon" : input == "Events" ? "non-shiny event Pokémon" : input == "Legendaries" ? "non-shiny legendary Pokémon" : input == "Paradoxes" ? "non-shiny paradox Pokémon" : ball != Ball.None ? ballStr : $"non-shiny {input}";
-            string exclude = ball is Ball.Cherish || input == "Events" ? ", legendaries, paradoxes" : input == "Legendaries" ? ", events, paradoxes," : input == "Paradoxes" ? ", events, legendaries," : $", events,{(isLegend ? "" : " legendaries,")}{(isParadox ? "" : " paradoxes,")}"; 
+            string exclude = ball is Ball.Cherish || input == "Events" ? ", legendaries, paradoxes" : input == "Legendaries" ? ", events, paradoxes," : input == "Paradoxes" ? ", events, legendaries," : $", events,{(isLegend ? "" : " legendaries,")}{(isParadox ? "" : " paradoxes,")}";
             result.Message = input == "" ? "Every non-shiny Pokémon was released, excluding Ditto, favorites, events, buddy, legendaries, and those in daycare." : $"Every {generalOutput} was released, excluding favorites, buddy{exclude} and those in daycare.";
             return true;
         }
@@ -918,7 +918,7 @@ public class TradeCordHelper<T> : TradeCordDatabase<T> where T : PKM, new()
             bool isLegend = IsLegendaryOrMythical(pk.Species);
 
             var names = CatchValues.Replace(" ", "").Split(',');
-            var obj = new object[] { m_user.UserInfo.UserID, newID, match.Shiny, match.Ball, match.Nickname, match.Species, match.Form, match.Egg, false, false, isLegend, match.Event, match.Gmax }; 
+            var obj = new object[] { m_user.UserInfo.UserID, newID, match.Shiny, match.Ball, match.Nickname, match.Species, match.Form, match.Egg, false, false, isLegend, match.Event, match.Gmax };
             result.SQLCommands.Add(DBCommandConstructor("catches", CatchValues, "", names, obj, SQLTableContext.Insert));
 
             names = BinaryCatchesValues.Replace(" ", "").Split(',');
@@ -1455,7 +1455,7 @@ public class TradeCordHelper<T> : TradeCordDatabase<T> where T : PKM, new()
                 return false;
             }
 
-            var oldName = pk.IsNicknamed ? pk.Nickname : $"{SpeciesName.GetSpeciesNameGeneration(pk.Species, 2, 8)}{TradeExtensions<T>.FormOutput(pk.Species, pk.Form, out _)}";
+            var oldName = pk.IsNicknamed ? pk.Nickname : $"{SpeciesName.GetSpeciesNameGeneration(pk.Species, 2, 9)}{TradeExtensions<T>.FormOutput(pk.Species, pk.Form, out _)}";
             var timeStr = TimeOfDayString(user.UserInfo.TimeZoneOffset, false);
             var tod = TradeExtensions<T>.EnumParse<TimeOfDay>(timeStr);
             if (tod is TimeOfDay.Dawn)
@@ -1470,7 +1470,7 @@ public class TradeCordHelper<T> : TradeCordDatabase<T> where T : PKM, new()
             }
 
             var form = TradeExtensions<T>.FormOutput(pk.Species, pk.Form, out _);
-            var species = SpeciesName.GetSpeciesNameGeneration(pk.Species, 2, 8);
+            var species = SpeciesName.GetSpeciesNameGeneration(pk.Species, 2, 9);
 
             user.Catches[match.ID].Species = species;
             user.Catches[match.ID].Form = form;


### PR DESCRIPTION
This PR has two commits.

The first commit updates evolution criteria used in TradeCord for Pokémon added in Pokémon Legends: Arceus and Scarlet/Violet. It does not actually re-enable evolution in TradeCord, but rather updates the logic that determines whether and how such Pokémon can and should evolve.

The second commit _does_ re-enable evolution in TradeCord.

For best results, this PR should be rebased on #50 after that PR is incorporated into the main branch because many of these new evolutions require the evolution items that PR adds. (It may be suitable to test with both only the first commit of #50 and both of the two, as the second adds the Peat Block item.)

**This PR should be tested before deploying!**