### PR TITLE
[Tradecord] fixes to buddy friendship

### DIFF
--- a/SysBot.Pokemon/TradeCord/TradeCordHelper.cs
+++ b/SysBot.Pokemon/TradeCord/TradeCordHelper.cs
@@ -687,7 +687,7 @@ public class TradeCordHelper<T> : TradeCordDatabase<T> where T : PKM, new()
             bool isParadox = IsParadox((ushort)speciesID);
             string ballStr = ball != Ball.None ? $"Pokémon in {ball} Ball" : "";
             string generalOutput = input == "Shinies" ? "shiny Pokémon" : input == "Events" ? "non-shiny event Pokémon" : input == "Legendaries" ? "non-shiny legendary Pokémon" : input == "Paradoxes" ? "non-shiny paradox Pokémon" : ball != Ball.None ? ballStr : $"non-shiny {input}";
-            string exclude = ball is Ball.Cherish || input == "Events" ? ", legendaries, paradoxes" : input == "Legendaries" ? ", events, paradoxes," : input == "Paradoxes" ? ", events, legendaries," : $", events,{(isLegend ? "" : " legendaries,")}{(isParadox ? "" : " paradoxes,")}"; 
+            string exclude = ball is Ball.Cherish || input == "Events" ? ", legendaries, paradoxes" : input == "Legendaries" ? ", events, paradoxes," : input == "Paradoxes" ? ", events, legendaries," : $", events,{(isLegend ? "" : " legendaries,")}{(isParadox ? "" : " paradoxes,")}";
             result.Message = input == "" ? "Every non-shiny Pokémon was released, excluding Ditto, favorites, events, buddy, legendaries, and those in daycare." : $"Every {generalOutput} was released, excluding favorites, buddy{exclude} and those in daycare.";
             return true;
         }
@@ -918,7 +918,7 @@ public class TradeCordHelper<T> : TradeCordDatabase<T> where T : PKM, new()
             bool isLegend = IsLegendaryOrMythical(pk.Species);
 
             var names = CatchValues.Replace(" ", "").Split(',');
-            var obj = new object[] { m_user.UserInfo.UserID, newID, match.Shiny, match.Ball, match.Nickname, match.Species, match.Form, match.Egg, false, false, isLegend, match.Event, match.Gmax }; 
+            var obj = new object[] { m_user.UserInfo.UserID, newID, match.Shiny, match.Ball, match.Nickname, match.Species, match.Form, match.Egg, false, false, isLegend, match.Event, match.Gmax };
             result.SQLCommands.Add(DBCommandConstructor("catches", CatchValues, "", names, obj, SQLTableContext.Insert));
 
             names = BinaryCatchesValues.Replace(" ", "").Split(',');
@@ -2210,46 +2210,52 @@ public class TradeCordHelper<T> : TradeCordDatabase<T> where T : PKM, new()
                     user.Catches[match.ID].Nickname = pk.Nickname;
                 }
             }
-            else if (pk.CurrentLevel < 100 && result.Poke.Species is not 0)
+            else if (result.Poke.Species is not 0)
             {
                 var enc = result.Poke;
                 var sootheBell = pk.HeldItem is 218 && pk.CurrentFriendship + 2 <= 255 ? 2 : 0;
                 var shiny = enc.IsShiny && pk.CurrentFriendship + 5 + sootheBell <= 255 ? 5 : 0;
-                pk.CurrentFriendship = (byte)(sootheBell + shiny);
+                pk.CurrentFriendship = Math.Min(pk.CurrentFriendship + sootheBell + shiny, 255);
 
-                int levelOld = pk.CurrentLevel;
-                var xpMin = Experience.GetEXP((byte)(pk.CurrentLevel + 1), pk.PersonalInfo.EXPGrowth);
-                var calc = enc.PersonalInfo.BaseEXP * enc.CurrentLevel / 5.0 * Math.Pow((2.0 * enc.CurrentLevel + 10.0) / (enc.CurrentLevel + pk.CurrentLevel + 10.0), 2.5);
-                var bonus = enc.IsShiny ? 1.1 : 1.0;
-                var xpGet = (uint)Math.Round(calc * bonus, 0, MidpointRounding.AwayFromZero);
-                if (xpGet < 100)
-                    xpGet = 175;
-
-                pk.EXP += xpGet;
-                while (pk.EXP >= Experience.GetEXP((byte)(pk.CurrentLevel + 1), pk.PersonalInfo.EXPGrowth) && pk.CurrentLevel < 100)
-                    pk.CurrentLevel++;
-
-                if (pk.CurrentLevel is 100)
-                    pk.EXP = xpMin;
-
-                if (pk.EXP >= xpMin)
+                if (pk.CurrentLevel < 100)
                 {
-                    buddyMsg = $"\n{user.Buddy.Nickname} gained {xpGet} EXP and leveled up to level {pk.CurrentLevel}!";
-                    if (pk.CurrentFriendship < 255)
+                    int levelOld = pk.CurrentLevel;
+                    var xpMin = Experience.GetEXP((byte)(pk.CurrentLevel + 1), pk.PersonalInfo.EXPGrowth);
+                    var calc = enc.PersonalInfo.BaseEXP * enc.CurrentLevel / 5.0 * Math.Pow((2.0 * enc.CurrentLevel + 10.0) / (enc.CurrentLevel + pk.CurrentLevel + 10.0), 2.5);
+                    var bonus = enc.IsShiny ? 1.1 : 1.0;
+                    var xpGet = (uint)Math.Round(calc * bonus, 0, MidpointRounding.AwayFromZero);
+                    if (xpGet < 100)
+                        xpGet = 175;
+
+                    pk.EXP += xpGet;
+                    while (pk.EXP >= Experience.GetEXP((byte)(pk.CurrentLevel + 1), pk.PersonalInfo.EXPGrowth) && pk.CurrentLevel < 100)
+                        pk.CurrentLevel++;
+
+                    if (pk.CurrentLevel is 100)
+                        pk.EXP = xpMin;
+
+                    if (pk.EXP >= xpMin)
                     {
-                        var delta = pk.CurrentLevel - levelOld;
-                        for (int i = 0; i < delta; i++)
+                        buddyMsg = $"\n{user.Buddy.Nickname} gained {xpGet} EXP and leveled up to level {pk.CurrentLevel}!";
+                        if (pk.CurrentFriendship < 255)
                         {
-                            if (pk.CurrentFriendship + 2 >= 255)
+                            var delta = pk.CurrentLevel - levelOld;
+                            for (int i = 0; i < delta; i++)
                             {
-                                pk.CurrentFriendship = 255;
-                                break;
+                                if (pk.CurrentFriendship + 2 >= 255)
+                                {
+                                    pk.CurrentFriendship = 255;
+                                    break;
+                                }
+                                pk.CurrentFriendship += 2;
                             }
-                            pk.CurrentFriendship += 2;
                         }
                     }
+                    else
+                    {
+                        buddyMsg = $"\n{user.Buddy.Nickname} gained {xpGet} EXP!";
+                    }
                 }
-                else buddyMsg = $"\n{user.Buddy.Nickname} gained {xpGet} EXP!";
             }
 
             var names = new string[] { "@data", "@user_id", "@id" };
@@ -2315,7 +2321,7 @@ public class TradeCordHelper<T> : TradeCordDatabase<T> where T : PKM, new()
         int[] array = result.User.Catches.Select(x => x.Value.ID).ToArray();
         array = array.OrderBy(x => x).ToArray();
         index = Indexing(array);
-        result.User.Catches.Add(index, new() { Species = speciesName, Nickname = pk.Nickname, Ball = $"{(Ball)pk.Ball}", Egg = pk.IsEgg, Form = form, ID = index, Shiny = pk.IsShiny, Traded = false, Favorite = false, Legendary = isLegend, Event = pk.FatefulEncounter, Gmax = canGmax});
+        result.User.Catches.Add(index, new() { Species = speciesName, Nickname = pk.Nickname, Ball = $"{(Ball)pk.Ball}", Egg = pk.IsEgg, Form = form, ID = index, Shiny = pk.IsShiny, Traded = false, Favorite = false, Legendary = isLegend, Event = pk.FatefulEncounter, Gmax = canGmax });
 
         var names = CatchValues.Replace(" ", "").Replace("-", "").Split(',');
         var obj = new object[] { result.User.UserInfo.UserID, index, pk.IsShiny, $"{(Ball)pk.Ball}", pk.Nickname, speciesName, form, pk.IsEgg, false, false, isLegend, pk.FatefulEncounter, canGmax, isParadox };


### PR DESCRIPTION
First off, before this commit, when not leveling up, the current buddy's friendship would always be _set_ to 0, 2, 5 or 7. This commit changes that to increment by that value (or cap at 255), as probably intended.

Second, it allows friendship to increase even if the buddy's level is already 100.