### PR TITLE
Add Recovery Filters and Related functionality

### DIFF
--- a/SysBot.Pokemon/SV/BotRaid/RaidEnum.cs
+++ b/SysBot.Pokemon/SV/BotRaid/RaidEnum.cs
@@ -28,6 +28,13 @@ namespace SysBot.Pokemon
         MashA,
     }
 
+    public enum RecoveryAction
+    {
+        Nothing,
+        Disable,
+        Delete,
+    }
+
     public class BanList
     {
         public bool enabled { get; set; }

--- a/SysBot.Pokemon/SV/BotRotatingRaid/RotatingRaidSettingsSV.cs
+++ b/SysBot.Pokemon/SV/BotRotatingRaid/RotatingRaidSettingsSV.cs
@@ -48,6 +48,9 @@ public class RotatingRaidSettingsSV : IBotStateSettings, ICountSettings
     [Category(FeatureToggle), Description("When enabled, the embed will countdown the amount of seconds in \"TimeToWait\" until starting the raid.")]
     public bool IncludeCountdown { get; set; } = false;
 
+    [Category(Hosting), Description("Recovery Settings"), DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public RotatingRaidRecoveryFiltersCategory RecoveryFilters { get; set; } = new();
+
     [Category(Hosting), Description("Lobby Options"), DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
     public LobbyFiltersCategory LobbyOptions { get; set; } = new();
 
@@ -104,6 +107,32 @@ public class RotatingRaidSettingsSV : IBotStateSettings, ICountSettings
         public string Seed { get; set; } = "0";
         public MoveType TeraType { get; set; } = MoveType.Any;
         public string Title { get; set; } = string.Empty;
+    }
+
+    [Category(Hosting), TypeConverter(typeof(CategoryConverter<RotatingRaidRecoveryFiltersCategory>))]
+    public class RotatingRaidRecoveryFiltersCategory
+    {
+        public override string ToString() => "Recovery Settings";
+        [Category(Hosting), Description("Set whether or not Mighty is active or not.")]
+        public bool MightyActive { get; set; } = false;
+
+        [Category(Hosting), Description("Automatically detect the start/end of Distribution.")]
+        public bool AutoSetDistribution { get; set; } = false;
+
+        [Category(Hosting), Description("Override for Distribution Active.")]
+        public bool DistributionActive { get; set; } = false;
+
+        [Category(Hosting), Description("Nothing = Do nothing, Disable = Sets ActiveInRotation to false, Delete = Deletes the Parameter")]
+        public RecoveryAction ActionOnEnd { get; set; } = RecoveryAction.Nothing;
+
+        [Category(Hosting), Description("Set the crystal type to look for, Base = Any.")]
+        public TeraCrystalType CrystalType { get; set; } = TeraCrystalType.Base;
+
+        [Category(Hosting), Description("Set the targeted difficulty for the den, 0 = Any.")]
+        public int TargetDifficulty { get; set; } = 0;
+
+        [Category(Hosting), Description("Set the target Pokemon, None = Any.")]
+        public Species TargetSpecies { get; set; } = Species.None;
     }
 
     [Category(Hosting), TypeConverter(typeof(CategoryConverter<RotatingRaidPresetFiltersCategory>))]


### PR DESCRIPTION
### Features
* Updated Raid Recovery Logic
* Added Recovery Filters
*   * Adds the ability to search for specific dens
*   * Adds the ability to search for a specific Pokemon (Useful during multi Pokemon events)
*  * Adds the ability to search for a specific star Level (Useful during events with shiny limitations i.e Gimmighoul)
*  * Adds the option to automatically clear event seeds on distribution end (Delete, Disable or Do nothing)
![image](https://github.com/user-attachments/assets/585743e6-2146-481c-b33b-8d2787ea032f)

Built in safeguards for invalid recovery selections
- Wont look for Distribution raids if the DistributionActive isn't set (Automatically enabled if AutoSetDistribution) is on

Works for Mighty, but due to there only being 1 mighty den, if you host non Mighty raids on the mighty den, the setting would be turned off. Hence the no AutoSetMighty functionality, so you have to manually enable that and disable it some time before event end / enable it before event start.

