### PR TITLE
Fix day roll tracking

### DIFF
--- a/SysBot.Pokemon/SV/BotRaid/RaidBotSV.cs
+++ b/SysBot.Pokemon/SV/BotRaid/RaidBotSV.cs
@@ -305,6 +305,10 @@ namespace SysBot.Pokemon
                     dayRoll++;
                     continue;
                 }
+                else
+                {
+                    dayRoll = 0;
+                }
 
                 if (Hub.Config.Stream.CreateAssets)
                     await GetRaidSprite(token).ConfigureAwait(false);


### PR DESCRIPTION
If the day rolls over twice, the bot will stop executing on the second rollover even if it would've successfully recovered. This is because the `dayRoll` count is not reset upon successfully reading the desired raid.

You can easily test this by using TimeSkip as the rollover prevention method and having the initial system time set to 10 minutes before the next day. After 20+ minutes, you'll notice the bot stops. If you check logs, you'll see it detect a rollover and recover 10 minutes in but then detect a rollover another 10 minutes later and end the bot.

It looks like this is an issue with `RotatingRaidBotSV` too, but I've never used that bot, so I will leave it to you to fix that one.